### PR TITLE
Database Connection Pooling

### DIFF
--- a/src/audit/audit.go
+++ b/src/audit/audit.go
@@ -14,6 +14,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+const dbPoolCount = 500
+
 var client *mongo.Client
 
 func main() {
@@ -91,6 +93,9 @@ func setupIndexes(client *mongo.Client) {
 
 func connectToMongo() (*mongo.Client, error) {
 	clientOptions := options.Client().ApplyURI(serverurls.Env.AuditDBServer)
+	clientOptions.SetMaxPoolSize(dbPoolCount)
+	clientOptions.SetMinPoolSize(dbPoolCount)
+
 	client, err := mongo.Connect(context.TODO(), clientOptions)
 	if err != nil {
 		return nil, err

--- a/src/data/data.go
+++ b/src/data/data.go
@@ -14,6 +14,8 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+const dbPoolCount = 500
+
 var auditClient = auditclient.AuditClient{
 	Server: "database",
 }
@@ -68,6 +70,9 @@ func main() {
 
 	//hookup to mongo
 	clientOptions := options.Client().ApplyURI(serverurls.Env.DataDBServer)
+	clientOptions.SetMaxPoolSize(dbPoolCount)
+	clientOptions.SetMinPoolSize(dbPoolCount)
+
 	client, err := mongo.Connect(context.TODO(), clientOptions)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
I did some research into the golang mongo db driver, and we get connection pooling to the database for free. This PR just bumps up the connection count from the default of 100 to 500. 

See: https://godoc.org/go.mongodb.org/mongo-driver/mongo/options#ClientOptions.SetMaxPoolSize

